### PR TITLE
Custom Font Adjustment & Mouse Crash Fix

### DIFF
--- a/src/main/java/net/aoba/event/events/MouseClickEvent.java
+++ b/src/main/java/net/aoba/event/events/MouseClickEvent.java
@@ -14,6 +14,7 @@ public class MouseClickEvent extends AbstractEvent {
     public final double mouseY;
     public final MouseButton button;
     public final MouseAction action;
+    public final int buttonNumber;
 
     public MouseClickEvent(double mouseX, double mouseY, MouseButton button, MouseAction action) {
         super();
@@ -21,6 +22,16 @@ public class MouseClickEvent extends AbstractEvent {
         this.mouseY = mouseY;
         this.button = button;
         this.action = action;
+        this.buttonNumber = -1;
+    }
+
+    public MouseClickEvent(double mouseX, double mouseY, MouseButton button, MouseAction action, int buttonNumber) {
+        super();
+        this.mouseX = mouseX;
+        this.mouseY = mouseY;
+        this.button = button;
+        this.action = action;
+        this.buttonNumber = buttonNumber;
     }
 
 

--- a/src/main/java/net/aoba/gui/font/FontManager.java
+++ b/src/main/java/net/aoba/gui/font/FontManager.java
@@ -82,7 +82,7 @@ public class FontManager {
             if (files != null) {
                 for (File file : files) {
                     try {
-                        Font font = LoadTTFFont(file, 12.5f, 2, new TrueTypeFontLoader.Shift(-1, 0), "");
+                        Font font = LoadTTFFont(file, 9f, 2, new TrueTypeFontLoader.Shift(-1, 0), "");
                         List<Font.FontFilterPair> list = new ArrayList<>();
                         list.add(new Font.FontFilterPair(font, FilterMap.NO_FILTER));
                         LogUtils.getLogger().info("Loading font " + file.getName());

--- a/src/main/java/net/aoba/gui/navigation/NavigationBar.java
+++ b/src/main/java/net/aoba/gui/navigation/NavigationBar.java
@@ -24,6 +24,7 @@ import net.aoba.event.events.MouseClickEvent;
 import net.aoba.event.listeners.MouseClickListener;
 import net.aoba.gui.GuiManager;
 import net.aoba.gui.colors.Color;
+import net.aoba.gui.font.FontManager;
 import net.aoba.utils.render.Render2D;
 import net.aoba.utils.types.MouseAction;
 import net.aoba.utils.types.MouseButton;
@@ -103,7 +104,7 @@ public class NavigationBar implements MouseClickListener {
             if (i == selectedIndex) {
                 pane.render(drawContext, partialTicks);
             }
-            Render2D.drawString(drawContext, pane.title, centerX - ((float) width / 2) + 50 + (100 * i) - mc.textRenderer.getWidth(pane.title), 30, GuiManager.foregroundColor.getValue());
+            Render2D.drawString(drawContext, pane.title, centerX - ((float) width / 2) + 50 + (100 * i) - Render2D.getStringWidth(pane.title), 30, GuiManager.foregroundColor.getValue());
         }
     }
 

--- a/src/main/java/net/aoba/mixin/MouseMixin.java
+++ b/src/main/java/net/aoba/mixin/MouseMixin.java
@@ -68,6 +68,12 @@ public class MouseMixin {
                         event = new MouseClickEvent(x, y, MouseButton.RIGHT, MouseAction.UP);
                     }
                     break;
+                default:
+                    if (action == 1) {
+                        event = new MouseClickEvent(x, y, MouseButton.OTHER, MouseAction.DOWN, button);
+                    } else {
+                        event = new MouseClickEvent(x, y, MouseButton.OTHER, MouseAction.UP, button);
+                    }
             }
 
             aoba.eventManager.Fire(event);

--- a/src/main/java/net/aoba/utils/render/Render2D.java
+++ b/src/main/java/net/aoba/utils/render/Render2D.java
@@ -432,7 +432,8 @@ public class Render2D {
 	 * @param width    Width of the box.
 	 * @param height   Height of the box.
 	 * @param radius   Corner radius of the box outline.
-	 * @param color    Color of the outline of the box.
+	 * @param outlineColor    Color of the outline of the box.
+	 * @param backgroundColor Color of the background of the box.
 	 */
 	public static void drawOutlinedRoundedBox(Matrix4f matrix4f, float x, float y, float width, float height, float radius, Color outlineColor, Color backgroundColor) {
 		RenderSystem.enableBlend();
@@ -890,7 +891,7 @@ public class Render2D {
 	 * @return Width of text in pixels.
 	 */
 	public static int getStringWidth(String text) {
-		TextRenderer textRenderer = MinecraftClient.getInstance().textRenderer;
+		TextRenderer textRenderer = Aoba.getInstance().fontManager.GetRenderer();
 		return textRenderer.getWidth(text);
 	}
 }

--- a/src/main/java/net/aoba/utils/types/MouseButton.java
+++ b/src/main/java/net/aoba/utils/types/MouseButton.java
@@ -1,5 +1,5 @@
 package net.aoba.utils.types;
 
 public enum MouseButton {
-    LEFT, RIGHT, MIDDLE
+    LEFT, RIGHT, MIDDLE, OTHER
 }


### PR DESCRIPTION
Adjust default TTF font loading size to 9 from 12.5 to match minecraft scale
Adjust string width calculation to use the currently loaded font renderer, not minecraft's default text renderer
- This only fixes the tooltip background rendering to cover for custom fonts. If for some reason a loaded font is bigger than default, ClickGui windows will not expand to match the new font size. Hopefully forcing size 9 instead of 12.5 accomodates this for monospaced fonts.

Fix mouse button crash in event listener.
- Adds a mouse button int for other mouse buttons (ie side mouse buttons) if they are pressed. Previously this would cause a crash, now the event fires as normal and tracks which mouse button is pressed by button code. Can be adapted if module binds were to be made to include mouse buttons (i.e. I use my side mouse button `mouse_button_4` for zoom)